### PR TITLE
Add machinery for scratch variables + loehner refinement criteria

### DIFF
--- a/bin/baselines
+++ b/bin/baselines
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+uv run python -m kamayan.testing.baselines $*

--- a/docs/kamayan_docs.cpp
+++ b/docs/kamayan_docs.cpp
@@ -71,7 +71,7 @@ int main(int argc_in, char *argv_in[]) {
                                  std::to_string(args.unit_name.size() > 0) + ").")
 
     auto write_rps = [&](kamayan::KamayanUnit *unit) {
-      auto ss = kamayan::RuntimeParameterDocs(unit);
+      auto ss = kamayan::RuntimeParameterDocs(unit, pman->pinput.get());
       std::ofstream out_file(args.out_file);
       if (out_file.is_open()) {
         out_file << ss.str();

--- a/docs/kamayan_docs.in
+++ b/docs/kamayan_docs.in
@@ -1,3 +1,9 @@
 <parthenon/job>
 problem_id = make_task_list_graphs
 
+<parthenon/mesh>
+refinement = adaptive
+
+<kamayan/refinement0>
+field = dens
+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(_sources
     driver/kamayan_driver.cpp
     grid/grid.cpp
+    grid/grid_refinement.cpp
     kamayan/config.cpp
     kamayan/kamayan.cpp
     kamayan/runtime_parameters.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,6 +19,7 @@ add_library(kamayan OBJECT ${_sources})
 # maybe I should just glob for tests...
 set(_test_sources
     grid/tests/test_grid.cpp
+    grid/tests/test_scratch.cpp
     utils/tests/test_strings.cpp
     utils/tests/test_type_list.cpp
     utils/tests/test_type_list_array.cpp

--- a/src/driver/kamayan_driver.cpp
+++ b/src/driver/kamayan_driver.cpp
@@ -4,6 +4,7 @@
 #include <memory>
 #include <string>
 
+#include <amr_criteria/refinement_package.hpp>
 #include <parthenon/parthenon.hpp>
 
 #include "grid/grid.hpp"
@@ -157,10 +158,17 @@ TaskID KamayanDriver::BuildTaskList(TaskList &task_list, const Real &dt, const R
       }
     });
 
+    // lets us unit test the driver mechanics
+    if (pmesh == nullptr) return next;
+
     next = task_list.AddTask(next, "EstimateTimeStep",
                              parthenon::Update::EstimateTimestep<MeshData>, mbase.get());
     next = task_list.AddTask(next, "FillDerived",
                              parthenon::Update::FillDerived<MeshData>, mbase.get());
+    if (pmesh->adaptive) {
+      next = task_list.AddTask(next, "RefinementTagging",
+                               parthenon::Refinement::Tag<MeshData>, mbase.get());
+    }
   }
   return next;
 }

--- a/src/grid/grid.cpp
+++ b/src/grid/grid.cpp
@@ -75,7 +75,7 @@ void Setup(Config *cfg, runtime_parameters::RuntimeParameters *rps) {
   // kamayan refinement
   const std::string ref_block = "kamayan/refinement";
   int nref_vars = 0;
-  while (true && adaptive != "none") {
+  while (true && adaptive == "adaptive") {
     const std::string ref_block_n = ref_block + std::to_string(nref_vars);
     if (!rps->GetPin()->DoesBlockExist(ref_block_n)) {
       break;
@@ -100,8 +100,9 @@ Initialize(const Config *cfg, const runtime_parameters::RuntimeParameters *rps) 
   auto pkg = std::make_shared<StateDescriptor>("grid");
 
   const std::string ref_block = "kamayan/refinement";
+  auto adaptive = rps->Get<std::string>("parthenon/mesh", "refinement");
   int nref_vars = 0;
-  while (true) {
+  while (true && adaptive == "adaptive") {
     std::string ref_block_n = ref_block + std::to_string(nref_vars);
     if (!rps->GetPin()->DoesBlockExist(ref_block_n)) {
       break;

--- a/src/grid/grid.cpp
+++ b/src/grid/grid.cpp
@@ -2,10 +2,14 @@
 
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
+#include "driver/kamayan_driver_types.hpp"
+#include "grid/grid_refinement.hpp"
 #include "grid/grid_types.hpp"
 #include "grid/grid_update.hpp"
+#include "grid/scratch_variables.hpp"
 #include "kamayan/runtime_parameters.hpp"
 
 namespace kamayan::grid {
@@ -13,6 +17,7 @@ namespace kamayan::grid {
 std::shared_ptr<KamayanUnit> ProcessUnit() {
   auto grid_unit = std::make_shared<KamayanUnit>("grid");
   grid_unit->Setup = Setup;
+  grid_unit->Initialize = Initialize;
   return grid_unit;
 }
 
@@ -22,7 +27,8 @@ void Setup(Config *cfg, runtime_parameters::RuntimeParameters *rps) {
   // <parthenon/mesh>
   rps->Add<std::string>("parthenon/mesh", "refinement", "adaptive",
                         "Mesh refinement startegy.", {"adaptive", "static", "none"});
-  rps->Add<int>("parthenon/mesh", "numlevel", 1, "Number of refinement levels.");
+  auto global_max_level =
+      rps->GetOrAdd<int>("parthenon/mesh", "numlevel", 1, "Number of refinement levels.");
 
   rps->Add<int>("parthenon/mesh", "nx1", 32,
                 "Number of cells across the domain at level 0.");
@@ -63,6 +69,45 @@ void Setup(Config *cfg, runtime_parameters::RuntimeParameters *rps) {
   rps->Add<int>("parthenon/meshblock", "nx1", 16, "Size of meshblocks in x1.");
   rps->Add<int>("parthenon/meshblock", "nx2", 16, "Size of meshblocks in x2.");
   rps->Add<int>("parthenon/meshblock", "nx3", 16, "Size of meshblocks in x3.");
+
+  // kamayan refinement
+  const std::string ref_block = "kamayan/refinement";
+  auto nref_vars =
+      rps->GetOrAdd(ref_block, "nref_vars", 1, "Number of variables to refine on.");
+  for (int n = 1; n <= nref_vars; n++) {
+    const std::string ref_block_n = ref_block + std::to_string(n);
+    rps->Add<std::string>(ref_block_n, "field", "NO FIELD WAS SET",
+                          "Field to refine on.");
+    rps->Add<std::string>(ref_block_n, "method", "loehner",
+                          "Method to use for refinement",
+                          {"loehner", "derivative_order_1", "derivative_order_2"});
+    rps->Add<Real>(ref_block_n, "refine_tol", 0.8, "Error threshold for refinement");
+    rps->Add<Real>(ref_block_n, "derefine_tol", 0.2, "Error threshold for derefinement");
+    rps->Add<Real>(ref_block_n, "filter", 0.01,
+                   "Noise filtering strength used in Loehner estimator.");
+    rps->Add<int>(ref_block_n, "max_level", global_max_level,
+                  "max refinement level for this field.");
+  }
+}
+
+std::shared_ptr<StateDescriptor>
+Initialize(const Config *cfg, const runtime_parameters::RuntimeParameters *rps) {
+  auto pkg = std::make_shared<StateDescriptor>("grid");
+
+  const std::string ref_block = "kamayan/refinement";
+  auto nref_vars = rps->Get<int>(ref_block, "nref_vars");
+  int nvars_to_refine = 0;
+  for (int n = 1; n <= nref_vars; n++) {
+    std::string ref_block_n = ref_block + std::to_string(n);
+    const auto field = rps->Get<std::string>(ref_block_n, "field");
+    if (field != "NO FIELD WAS SET") {
+      nvars_to_refine += 1;
+      pkg->amr_criteria.push_back(MakeAMRCriteria(rps, ref_block_n));
+    }
+    if (nvars_to_refine > 0) AddScratch<RefinementScratch>(pkg.get());
+  }
+
+  return pkg;
 }
 
 TaskStatus FluxesToDuDt(MeshData *md, MeshData *dudt) {

--- a/src/grid/grid.hpp
+++ b/src/grid/grid.hpp
@@ -19,6 +19,8 @@ namespace kamayan::grid {
 std::shared_ptr<KamayanUnit> ProcessUnit();
 
 void Setup(Config *cfg, runtime_parameters::RuntimeParameters *rps);
+std::shared_ptr<StateDescriptor>
+Initialize(const Config *cfg, const runtime_parameters::RuntimeParameters *rps);
 
 template <typename Container>
 requires(std::is_same_v<Container, MeshData> || std::is_same_v<Container, MeshBlockData>)

--- a/src/grid/grid_refinement.cpp
+++ b/src/grid/grid_refinement.cpp
@@ -2,6 +2,7 @@
 
 #include <cstdlib>
 #include <iostream>
+#include <limits>
 #include <memory>
 #include <string>
 #include <utility>
@@ -129,8 +130,9 @@ void AMRLoehner::operator()(MeshData *md,
                   denominator += std::pow(denom, 2);
                 }
               }
-              loc_max_err_2 = Kokkos::max(loc_max_err_2, numerator / denominator);
-              pack_der(b, FirstDer(2), k, j, i) = std::sqrt(numerator);
+              loc_max_err_2 = denominator == 0.0
+                                  ? loc_max_err_2
+                                  : Kokkos::max(loc_max_err_2, numerator / denominator);
             },
             Kokkos::Max<Real>(max_err_2));
         auto tags_access = scatter_tags.access();

--- a/src/grid/grid_refinement.cpp
+++ b/src/grid/grid_refinement.cpp
@@ -1,0 +1,115 @@
+#include "grid_refinement.hpp"
+
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "grid/grid.hpp"
+#include "grid/grid_types.hpp"
+#include "kokkos_abstraction.hpp"
+
+namespace kamayan::grid {
+std::shared_ptr<parthenon::AMRCriteria>
+MakeAMRCriteria(const runtime_parameters::RuntimeParameters *rps,
+                std::string block_name) {
+  auto method_str = rps->Get<std::string>(block_name, "method");
+  auto method = MapStrToEnum<RefinementCriteria>(
+      method_str, std::make_pair(RefinementCriteria::loehner, "loehner"),
+      std::make_pair(RefinementCriteria::first, "derivative_order_1"),
+      std::make_pair(RefinementCriteria::second, "derivative_order_2"));
+
+  if (method == RefinementCriteria::first || method == RefinementCriteria::second) {
+    // parthenon built in
+    return parthenon::AMRCriteria::MakeAMRCriteria(method_str, rps->GetPin(), block_name);
+  }
+  return std::make_shared<AMRLoehner>(rps, block_name);
+}
+
+void AMRLoehner::operator()(MeshData *md,
+                            parthenon::ParArray1D<AmrTag> &delta_level) const {
+  const auto desc =
+      MakePackDescriptor(md->GetMeshPointer()->resolved_packages.get(), {field});
+  auto pack = desc.GetPack(md);
+
+  const auto pack_der = GetPack<FirstDer>(md);
+
+  const int ndim = md->GetMeshPointer()->ndim;
+  auto ib = md->GetBoundsI(IndexDomain::interior);
+  auto jb = md->GetBoundsJ(IndexDomain::interior);
+  auto kb = md->GetBoundsK(IndexDomain::interior);
+
+  // this was just copied from
+  auto dims = md->GetMeshPointer()->resolved_packages->FieldMetadata(field).Shape();
+  const int k2d = ndim > 1 ? 1 : 0;
+  const int k3d = ndim > 2 ? 1 : 0;
+  int n5(0), n4(0);
+  if (dims.size() > 2) {
+    n5 = dims[1];
+    n4 = dims[2];
+  } else if (dims.size() > 1) {
+    n5 = dims[0];
+    n4 = dims[1];
+  }
+  const int var = comp4 + n4 * (comp5 + n5 * comp6);
+
+  // calculate derivatives
+  parthenon::par_for(
+      PARTHENON_AUTO_LABEL, 0, pack.GetNBlocks() - 1, kb.s - k3d, kb.e + k3d, jb.s - k2d,
+      jb.e + k2d, ib.s - 1, ib.e + 1,
+      KOKKOS_LAMBDA(const int b, const int k, const int j, const int i) {
+        const auto coords = pack.GetCoordinates(b);
+        using TE = TopologicalElement;
+        pack_der(b, FirstDer(0), k, j, i) =
+            0.5 * (pack(b, var, k, j, i + 1) - pack(b, var, k, j, i - 1)) /
+            coords.Dxc<1>();
+
+        if (ndim > 1)
+          pack_der(b, FirstDer(1), k, j, i) =
+              0.5 * (pack(b, var, k, j + 1, i) - pack(b, var, k, j - 1, i)) /
+              coords.Dxc<2>();
+
+        if (ndim > 2)
+          pack_der(b, FirstDer(2), k, j, i) =
+              0.5 * (pack(b, var, k + 1, j, i) - pack(b, var, k - 1, j, i)) /
+              coords.Dxc<3>();
+      });
+
+  auto scatter_tags = delta_level.ToScatterView<Kokkos::Experimental::ScatterMax>();
+  parthenon::par_for_outer(
+      PARTHENON_AUTO_LABEL, 0, 0, 0, pack.GetNBlocks() - 1, kb.s, kb.e, jb.s, jb.e,
+      KOKKOS_CLASS_LAMBDA(parthenon::team_mbr_t team_member, const int b, const int k,
+                          const int j) {
+        const auto coords = pack.GetCoordinates(b);
+        Real max_err_2 = 0.;
+        parthenon::par_reduce_inner(
+            parthenon::inner_loop_pattern_ttr_tag, team_member, ib.s, ib.e,
+            [&](const int i, Real &loc_max_err_2) {
+              // numerator = sum ( d2u_dpdq * dxpdxq )^2
+              // denominator = sum [ dxp*(d|u|_dp_+ + d|u|_dp_-)
+              //                    +eps*d2|u|_dpdq * dxpdxq]^2
+              using TE = TopologicalElement;
+              Real numerator = 0.0;
+              Real denominator = 0.0;
+              for (int q = 0; q < ndim; q++) {
+                auto fq = static_cast<TE>(q + static_cast<int>(TE::F1));
+                Kokkos::Array<int, 3> kji_q{(fq == TE::F3), (fq == TE::F2),
+                                            (fq == TE::F1)};
+                for (int p = 0; p < ndim; p++) {
+                  auto fp = static_cast<TE>(p + static_cast<int>(TE::F1));
+                  Kokkos::Array<int, 3> kji_p{(fp == TE::F3), (fp == TE::F2),
+                                              (fp == TE::F1)};
+
+                  numerator += Kokkos::pow(0.5 *
+                                               (pack_der(b, FirstDer(p), k + kji_q[0],
+                                                         j + kji_q[1], i + kji_q[0]) -
+                                                pack_der(b, FirstDer(p), k - kji_q[0],
+                                                         j - kji_q[1], i - kji_q[0])) /
+                                               coords.Dx(q),
+                                           2);
+                }
+              }
+            },
+            Kokkos::Max<Real>(max_err_2));
+      });
+}
+}  // namespace kamayan::grid

--- a/src/grid/grid_refinement.hpp
+++ b/src/grid/grid_refinement.hpp
@@ -1,0 +1,40 @@
+#ifndef GRID_GRID_REFINEMENT_HPP_
+#define GRID_GRID_REFINEMENT_HPP_
+#include <memory>
+#include <string>
+
+#include <amr_criteria/amr_criteria.hpp>
+
+#include "dispatcher/options.hpp"
+#include "grid/grid_types.hpp"
+#include "grid/scratch_variables.hpp"
+#include "kamayan/runtime_parameters.hpp"
+
+namespace kamayan {
+POLYMORPHIC_PARM(RefinementCriteria, loehner, first, second);
+}
+
+namespace kamayan::grid {
+using AmrTag = parthenon::AmrTag;
+
+// first-order derivative at centers used in Loehner estimator
+using FirstDer_t = ScratchVariable<"firstder", TopologicalType::Cell, 3>;
+
+using RefinementScratch = ScratchVariableList<FirstDer_t>;
+using FirstDer = RefinementScratch::type<FirstDer_t>;
+
+std::shared_ptr<parthenon::AMRCriteria>
+MakeAMRCriteria(const runtime_parameters::RuntimeParameters *rps, std::string block_name);
+
+struct AMRLoehner : public parthenon::AMRCriteria {
+  AMRLoehner(const runtime_parameters::RuntimeParameters *rps, std::string &block_name)
+      : AMRCriteria(rps->GetPin(), block_name),
+        filter(rps->Get<Real>(block_name, "filter")) {}
+  void operator()(MeshData *md,
+                  parthenon::ParArray1D<AmrTag> &delta_level) const override;
+
+ private:
+  Real filter;
+};
+}  // namespace kamayan::grid
+#endif  // GRID_GRID_REFINEMENT_HPP_

--- a/src/grid/scratch_variables.hpp
+++ b/src/grid/scratch_variables.hpp
@@ -103,6 +103,10 @@ struct ScratchVariable_impl : public SV::base_t {
   static constexpr int lb = lower;
   static constexpr int ub = lower + SV::size - 1;
 
+  template <class... Ts>
+  KOKKOS_INLINE_FUNCTION ScratchVariable_impl(Ts &&...args)
+      : SV::base_t(std::forward<Ts>(args)...) {}
+
   static std::string name() {
     return "scratch_" + TopologicalTypeToString(SV::type) + "_" + range_regex(lb, ub);
   }
@@ -135,7 +139,7 @@ requires(NonTypeTemplateSpecialization<V, ScratchVariable> &&
          (ScratchType<V::type, SVs> && ...))
 struct ScratchVariableList {
   static constexpr TopologicalType TT = V::type;
-  static constexpr int n_vars = V::size + (SVs::size + ...);
+  static constexpr int n_vars = V::size + (SVs::size + ... + 0);
   using TL = TypeList<V, SVs...>;
   using list = impl::SVList_impl<V, SVs...>;
 

--- a/src/grid/scratch_variables.hpp
+++ b/src/grid/scratch_variables.hpp
@@ -1,0 +1,154 @@
+#ifndef GRID_SCRATCH_VARIABLES_HPP_
+#define GRID_SCRATCH_VARIABLES_HPP_
+
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <utility>
+
+#include <parthenon/parthenon.hpp>
+
+#include "grid/grid_types.hpp"
+#include "kamayan/fields.hpp"
+#include "utils/type_abstractions.hpp"
+#include "utils/type_list.hpp"
+
+namespace kamayan {
+template <int... NCOMPS>
+using scratch_base_t = parthenon::variable_names::base_t<true, NCOMPS...>;
+
+// scratch variables are registered per-unit as sets of variables that
+// can each have their own shape, with the goal that the allocated memory
+// on each meshblock can be shared between packages, with no guarantees
+// about the persistence between unit layers.
+//
+// Some loose requirements
+// * scratch variables can have arbitrary shape
+//    * shape
+//    * TopologicalType
+// * even though they point to the same memory each unit might have their own
+//   variable types they will want to use to reference it
+// * There can't be any sane way to use these unless a unit is only allowed
+//   a single unique call to register its scratch variables
+KOKKOS_INLINE_FUNCTION constexpr auto TopologicalTypeToMetaData(TopologicalType tt) {
+  using TT = TopologicalType;
+  if (tt == TT::Face) {
+    return Metadata::Face;
+  } else if (tt == TT::Edge) {
+    return Metadata::Edge;
+  } else if (tt == TT::Node) {
+    return Metadata::Node;
+  }
+  return Metadata::Cell;
+}
+
+inline std::string TopologicalTypeToString(TopologicalType tt) {
+  using TT = TopologicalType;
+  if (tt == TT::Face) {
+    return "face";
+  } else if (tt == TT::Edge) {
+    return "edge";
+  } else if (tt == TT::Node) {
+    return "node";
+  }
+  return "cell";
+}
+
+inline std::string range_regex(unsigned a, unsigned b) {
+  std::ostringstream pattern;
+  pattern << "((" << std::to_string(a) << ")";
+  for (int i = a + 1; i <= b; i++) {
+    pattern << "|(" << std::to_string(i) << ")";
+  }
+  pattern << ")";
+  return pattern.str();
+}
+
+template <size_t N>
+struct CompileTimeString {
+  char value[N];
+
+  explicit(false) constexpr CompileTimeString(const char (&str)[N]) {
+    for (size_t i = 0; i < N; ++i)
+      value[i] = str[i];
+  }
+};
+
+template <CompileTimeString name, TopologicalType TT, int... NCOMPS>
+struct ScratchVariable {
+  using base_t = scratch_base_t<NCOMPS...>;
+  static constexpr std::string_view str_name{name.value, sizeof(name.value)};
+  static constexpr TopologicalType type = TT;
+  static constexpr int ncomps = sizeof...(NCOMPS);
+  static constexpr int size = (NCOMPS * ...);
+  static constexpr std::array<int, ncomps> shape{NCOMPS...};
+};
+
+template <TopologicalType TT, typename SV>
+concept ScratchType =
+    requires {
+      { SV::type } -> std::same_as<const TopologicalType &>;
+      { SV::ncomps } -> std::same_as<const int &>;
+      { SV::size } -> std::same_as<const int &>;
+      { SV::shape } -> std::same_as<const std::array<int, SV::ncomps> &>;
+    } && TT == SV::type && SV::ncomps == SV::ncomps && SV::size == SV::size &&
+    SV::shape == SV::shape;
+
+template <typename SV, int lower>
+requires(NonTypeTemplateSpecialization<SV, ScratchVariable>)
+struct ScratchVariable_impl : public SV::base_t {
+  using type = SV;
+  static constexpr int lb = lower;
+  static constexpr int ub = lower + SV::size - 1;
+
+  static std::string name() {
+    return "scratch_" + TopologicalTypeToString(SV::type) + "_" + range_regex(lb, ub);
+  }
+};
+
+namespace impl {
+template <typename...>
+struct SVList_impl {};
+
+template <typename SV>
+requires(NonTypeTemplateSpecialization<SV, ScratchVariable>)
+struct SVList_impl<SV> {
+  using type = ScratchVariable_impl<SV, 0>;
+  using value = TypeList<type>;
+};
+
+template <typename SV, typename... SVs>
+requires(ScratchType<SV::type, SVs> && ... &&
+         NonTypeTemplateSpecialization<SV, ScratchVariable>)
+struct SVList_impl<SV, SVs...> {
+  using list = SVList_impl<SVs...>;
+  using type = ScratchVariable_impl<SV, list::type::ub + 1>;
+  using value = ConcatTypeLists_t<TypeList<type>, typename list::value>;
+};
+}  // namespace impl
+
+// should take ScratchVariables...
+template <TopologicalType TT, typename... SVs>
+requires(ScratchType<TT, SVs> && ...)
+struct ScratchVariableList {
+  static constexpr int n_vars = (SVs::size + ...);
+  using TL = TypeList<SVs...>;
+  using list = impl::SVList_impl<SVs...>;
+
+  template <typename SV>
+  using type = list::value::template type<TL::template Idx<SV>()>;
+
+  auto GetVarNames() {
+    std::array<std::string, n_vars> vars;
+    auto base = "scratch_" + TopologicalTypeToString(TT) + "_";
+    for (int i = 0; i < n_vars; i++) {
+      vars[i] = base + std::to_string(i);
+    }
+    return vars;
+  }
+};
+
+}  // namespace kamayan
+
+#endif  // GRID_SCRATCH_VARIABLES_HPP_

--- a/src/grid/tests/test_scratch.cpp
+++ b/src/grid/tests/test_scratch.cpp
@@ -10,7 +10,7 @@ namespace kamayan {
 using TT = TopologicalType;
 using scratch_cell_1 = ScratchVariable<"one", TT::Cell, 3>;
 using scratch_cell_2 = ScratchVariable<"two", TT::Cell, 2, 4>;
-using scratch_list = ScratchVariableList<TT::Cell, scratch_cell_1, scratch_cell_2>;
+using scratch_list = ScratchVariableList<scratch_cell_1, scratch_cell_2>;
 using sc1 = scratch_list::type<scratch_cell_1>;
 using sc2 = scratch_list::type<scratch_cell_2>;
 

--- a/src/grid/tests/test_scratch.cpp
+++ b/src/grid/tests/test_scratch.cpp
@@ -1,0 +1,40 @@
+#include <gtest/gtest.h>
+
+#include <string>
+#include <type_traits>
+
+#include "grid/grid_types.hpp"
+#include "grid/scratch_variables.hpp"
+
+namespace kamayan {
+using TT = TopologicalType;
+using scratch_cell_1 = ScratchVariable<"one", TT::Cell, 3>;
+using scratch_cell_2 = ScratchVariable<"two", TT::Cell, 2, 4>;
+using scratch_list = ScratchVariableList<TT::Cell, scratch_cell_1, scratch_cell_2>;
+using sc1 = scratch_list::type<scratch_cell_1>;
+using sc2 = scratch_list::type<scratch_cell_2>;
+
+TEST(grid, scratchvariablelist) {
+  // they're added into the underlying TypeList going from right to left
+  // but from a user perspective this is just an implementation detail
+  // never going to need to know this
+  static_assert(std::is_same_v<scratch_list::type<scratch_cell_2>,
+                               ScratchVariable_impl<scratch_cell_2, 0>>);
+  static_assert(std::is_same_v<scratch_list::type<scratch_cell_1>,
+                               ScratchVariable_impl<scratch_cell_1, 8>>);
+
+  // check that the regex generated for the list will correctly match
+  std::string base_str = "scratch_cell_";
+  auto name1 = sc1::name();
+  auto name2 = sc2::name();
+  int nmatch1 = 0;
+  int nmatch2 = 0;
+  for (int i = 0; i < 100; i++) {
+    std::string test_str = base_str + std::to_string(i);
+    if (std::regex_match(test_str, std::regex(name1))) nmatch1 += 1;
+    if (std::regex_match(test_str, std::regex(name2))) nmatch2 += 1;
+  }
+  EXPECT_EQ(nmatch1, scratch_cell_1::size);
+  EXPECT_EQ(nmatch2, scratch_cell_2::size);
+}
+}  // namespace kamayan

--- a/src/kamayan/runtime_parameters.cpp
+++ b/src/kamayan/runtime_parameters.cpp
@@ -50,7 +50,7 @@ void RuntimeParameters::Add<Real>(const std::string &block, const std::string &k
                                   std::initializer_list<Rule<Real>> rules) {
   require_new_parm_throw(block + key);
   const Real read_Real = pin->GetOrAddReal(block, key, value);
-  parms[block + key] = Parameter<Real>(block, key, docstring, read_Real, rules);
+  parms[block + key] = Parameter<Real>(block, key, docstring, read_Real, rules, value);
 }
 
 template <>
@@ -60,7 +60,8 @@ void RuntimeParameters::Add<std::string>(const std::string &block, const std::st
                                          std::initializer_list<Rule<std::string>> rules) {
   require_new_parm_throw(block + key);
   const std::string read_string = strings::lower(pin->GetOrAddString(block, key, value));
-  parms[block + key] = Parameter<std::string>(block, key, docstring, read_string, rules);
+  parms[block + key] =
+      Parameter<std::string>(block, key, docstring, read_string, rules, value);
 }
 
 template <>
@@ -69,7 +70,7 @@ void RuntimeParameters::Add<int>(const std::string &block, const std::string &ke
                                  std::initializer_list<Rule<int>> rules) {
   require_new_parm_throw(block + key);
   const int read_int = pin->GetOrAddInteger(block, key, value);
-  parms[block + key] = Parameter<int>(block, key, docstring, read_int, rules);
+  parms[block + key] = Parameter<int>(block, key, docstring, read_int, rules, value);
 }
 
 template <>
@@ -78,7 +79,7 @@ void RuntimeParameters::Add<bool>(const std::string &block, const std::string &k
                                   std::initializer_list<Rule<bool>> rules) {
   require_new_parm_throw(block + key);
   const bool read_bool = pin->GetOrAddBoolean(block, key, value);
-  parms[block + key] = Parameter<bool>(block, key, docstring, read_bool, rules);
+  parms[block + key] = Parameter<bool>(block, key, docstring, read_bool, rules, value);
 }
 
 }  // namespace kamayan::runtime_parameters

--- a/src/kamayan/runtime_parameters.hpp
+++ b/src/kamayan/runtime_parameters.hpp
@@ -198,7 +198,7 @@ class RuntimeParameters {
     return Get<T>(block, key);
   }
 
-  auto GetPin() { return pin; }
+  auto GetPin() const { return pin; }
 
  private:
   void require_exists_parm_throw(const std::string &key) const;

--- a/src/kamayan/runtime_parameters.hpp
+++ b/src/kamayan/runtime_parameters.hpp
@@ -11,12 +11,13 @@
 
 #include <parthenon/parthenon.hpp>
 
+#include "driver/kamayan_driver_types.hpp"
 #include "grid/grid_types.hpp"
 #include "utils/strings.hpp"
 
 namespace kamayan {
 struct KamayanUnit;
-std::stringstream RuntimeParameterDocs(const KamayanUnit *unit);
+std::stringstream RuntimeParameterDocs(const KamayanUnit *unit, ParameterInput *pin);
 }  // namespace kamayan
 
 namespace kamayan::runtime_parameters {
@@ -120,7 +121,8 @@ requires(Rparm<T>)
 struct Parameter {
   Parameter() {}
   Parameter(const std::string &block_, const std::string key_,
-            const std::string &docstring_, const T &value_, std::vector<Rule<T>> rules)
+            const std::string &docstring_, const T &value_, std::vector<Rule<T>> rules,
+            const T &def_val)
       : block(block_), key(key_), docstring(impl::ToDocString(docstring_, rules)),
         value(value_) {
     if (rules.size() > 0) {
@@ -137,11 +139,11 @@ struct Parameter {
     }
     std::string default_str;
     if constexpr (std::is_same_v<T, std::string>) {
-      default_str = value_;
+      default_str = def_val;
     } else if constexpr (std::is_same_v<T, bool>) {
-      default_str = value_ ? "true" : "false";
+      default_str = def_val ? "true" : "false";
     } else {
-      default_str = std::to_string(value_);
+      default_str = std::to_string(def_val);
       if (default_str.size() > 5) {
         default_str = std::format("{:.5e}", static_cast<Real>(value_));
       }
@@ -160,7 +162,8 @@ struct Parameter {
 };
 
 class RuntimeParameters {
-  friend std::stringstream kamayan::RuntimeParameterDocs(const KamayanUnit *unit);
+  friend std::stringstream kamayan::RuntimeParameterDocs(const KamayanUnit *unit,
+                                                         ParameterInput *pin);
 
  public:
   RuntimeParameters() {}

--- a/src/kamayan/unit.cpp
+++ b/src/kamayan/unit.cpp
@@ -63,12 +63,12 @@ UnitCollection ProcessUnits() {
   return unit_collection;
 }
 
-std::stringstream RuntimeParameterDocs(const KamayanUnit *unit) {
+std::stringstream RuntimeParameterDocs(const KamayanUnit *unit, ParameterInput *pin) {
   std::stringstream ss;
   if (unit->Setup != nullptr) {
     Config cfg;
-    ParameterInput pin;
-    runtime_parameters::RuntimeParameters rps(&pin);
+    // ParameterInput pin;
+    runtime_parameters::RuntimeParameters rps(pin);
     unit->Setup(&cfg, &rps);
 
     std::map<std::string, std::list<std::string>> block_keys;

--- a/src/kamayan/unit.hpp
+++ b/src/kamayan/unit.hpp
@@ -91,7 +91,7 @@ UnitCollection ProcessUnits();
 
 // write out all the doc strings for runtime parameters
 // registered by a given unit
-std::stringstream RuntimeParameterDocs(const KamayanUnit *unit, std::string out_file);
+std::stringstream RuntimeParameterDocs(const KamayanUnit *unit, ParameterInput *pin);
 
 }  // namespace kamayan
 

--- a/src/problems/mhd_blast.in
+++ b/src/problems/mhd_blast.in
@@ -1,17 +1,20 @@
 <parthenon/job>
 problem_id = mhd_blast
 
-<parthenon/mesh>
-refinement = none
-# numlevel = 3
+<kamayan/refinement0>
+field = pres
 
-nx1 = 128
+<parthenon/mesh>
+refinement = adaptive
+numlevel = 3
+
+nx1 = 32
 x1min = -0.5
 x1max = 0.5
 ix1_bc = outflow
 ox1_bc = outflow
 
-nx2 = 128
+nx2 = 32
 x2min = -0.5
 x2max = 0.5
 ix2_bc = outflow
@@ -26,8 +29,8 @@ ox3_bc = outflow
 nghost = 4
 
 <parthenon/meshblock>
-nx1 = 32
-nx2 = 32
+nx1 = 8
+nx2 = 8
 nx3 = 1
 
 <parthenon/time>

--- a/src/problems/sedov.cpp
+++ b/src/problems/sedov.cpp
@@ -81,7 +81,7 @@ std::shared_ptr<StateDescriptor> Initialize(const Config *config,
   const int nx = rps->Get<int>("parthenon/mesh", "nx1");
   const Real xmin = rps->Get<Real>("parthenon/mesh", "x1min");
   const Real xmax = rps->Get<Real>("parthenon/mesh", "x1max");
-  const Real dx = std::pow(2, nlevels - 1) * (xmax - xmin) / static_cast<Real>(nx);
+  const Real dx = (xmax - xmin) / (std::pow(2, nlevels - 1) * static_cast<Real>(nx));
   const Real radius = 3.5 * dx;
 
   const Real pres =

--- a/src/problems/sedov.in
+++ b/src/problems/sedov.in
@@ -30,6 +30,9 @@ nx1 = 32
 nx2 = 32
 nx3 = 1
 
+<kamayan/refinement0>
+field = pres
+
 <parthenon/time>
 nlim = 10000
 tlim = 0.05

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -56,7 +56,7 @@ setup_test(
 setup_test(
   ${kamayan_NP_TESTING}
   "mhd_blast"
-  "--driver ${PROJECT_BINARY_DIR}/mhd_blast --driver_input ${PROJECT_SOURCE_DIR}/src/problems/mhd_blast.in --num_steps 2"
+  "--driver ${PROJECT_BINARY_DIR}/mhd_blast --driver_input ${PROJECT_SOURCE_DIR}/src/problems/mhd_blast.in --num_steps 3"
   "mhd_blast;baseline")
 
 setup_test(

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -62,5 +62,5 @@ setup_test(
 setup_test(
   ${kamayan_NP_TESTING}
   "sedov"
-  "--driver ${PROJECT_BINARY_DIR}/sedov --driver_input ${PROJECT_SOURCE_DIR}/src/problems/sedov.in --num_steps 2"
+  "--driver ${PROJECT_BINARY_DIR}/sedov --driver_input ${PROJECT_SOURCE_DIR}/src/problems/sedov.in --num_steps 3"
   "sedov;baseline")

--- a/tests/baselines/baseline_versions.json
+++ b/tests/baselines/baseline_versions.json
@@ -5,6 +5,12 @@
       "git_sha": "e3b445a84838e2349f593ede75a02bb74a55d6bb",
       "tar_sha": "955bb83fea17ba505e07f7284c3523c81ee2d60ab620d32cf196dee49a063f8dc831bf8f34c0c68544bb113ff80be67e2d094855ae636ca88623d849ecc9c111",
       "comment": "first baselines"
+    },
+    "2": {
+      "version": 2,
+      "git_sha": "3c4045c4a61c8e5bfec4b91edeb635f7b6ddd01b",
+      "tar_sha": "ba82a4ee3c16f81cb89d77d59c3627e970123b90afb2563f2db7e24129431869122bc82cc193519e22f4a363b03bf36df95b1c16dc8cf33ae95f7cd27a38e0be",
+      "comment": "Add AMR tests + divb checks for mhd_blast"
     }
   }
 }


### PR DESCRIPTION
Adds the utility to register derived fields as scratch, with a type trait that allows the same fields to be multiply aliased with arbitrary shapes.

This was needed to do the Loehner error estimator based refinement as a way to cache first derivatives on each mesh block between kernels.